### PR TITLE
fix(windows): start libvirtualhid UMDF device reliably

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,17 @@ powershell -ExecutionPolicy Bypass -File .\scripts\windows\uninstall-driver.ps1 
   -Force -RemoveCertificateSubject "CN=libvirtualhid CI Test Driver Signing"
 ```
 
-The helper stages the INF with `pnputil` and uses `devcon.exe` when available
-to create the `ROOT\LIBVIRTUALHID` development device.
+The helper stages the INF with `pnputil`, updates an existing
+`ROOT\LIBVIRTUALHID` device when present, and creates that root-enumerated
+device when it is missing. It uses `devcon.exe` when available, otherwise it
+uses SetupAPI/NewDev directly so MSI installs do not require the WDK tools on
+the target machine.
+
+The driver binary is a UMDF DLL installed through the Windows Driver Store, not
+a libvirtualhid `.sys` copied into `C:\Windows\System32\drivers`. Windows still
+uses its built-in `WUDFRd.sys` and VHF components under `System32\drivers`; the
+libvirtualhid-specific sign that installation completed is the
+`ROOT\LIBVIRTUALHID` device and the `\\.\LibVirtualHid` control device.
 
 Windows driver packages require a signed catalog for normal installation. Pull
 request builds generate a short-lived self-signed test certificate, sign

--- a/cmake/packaging/wix_resources/libvirtualhid-driver-installer.wxs
+++ b/cmake/packaging/wix_resources/libvirtualhid-driver-installer.wxs
@@ -26,8 +26,8 @@
                   Impersonate="no" />
 
     <InstallExecuteSequence>
-      <Custom Action="CA_LibVirtualHidInstallDriver" After="InstallFiles" Condition="NOT Installed AND UILevel &gt; 3" />
-      <Custom Action="CA_LibVirtualHidInstallDriverSilent" After="InstallFiles" Condition="NOT Installed AND UILevel &lt;= 3" />
+      <Custom Action="CA_LibVirtualHidInstallDriver" After="InstallFiles" Condition="NOT REMOVE=&quot;ALL&quot; AND UILevel &gt; 3" />
+      <Custom Action="CA_LibVirtualHidInstallDriverSilent" After="InstallFiles" Condition="NOT REMOVE=&quot;ALL&quot; AND UILevel &lt;= 3" />
       <Custom Action="CA_LibVirtualHidUninstallDriver" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot; AND UILevel &gt; 3" />
       <Custom Action="CA_LibVirtualHidUninstallDriverSilent" Before="RemoveFiles" Condition="REMOVE=&quot;ALL&quot; AND UILevel &lt;= 3" />
     </InstallExecuteSequence>

--- a/scripts/windows/install-driver.ps1
+++ b/scripts/windows/install-driver.ps1
@@ -70,6 +70,180 @@ function Import-DriverCertificate {
   }
 }
 
+function Add-SetupApiRootDeviceInstaller {
+  if (([System.Management.Automation.PSTypeName] "LibVirtualHid.SetupApi.RootDeviceInstaller").Type) {
+    return
+  }
+
+  Add-Type -TypeDefinition @"
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace LibVirtualHid.SetupApi {
+  public static class RootDeviceInstaller {
+    private const uint DicdGenerateId = 0x00000001;
+    private const uint DifRegisterDevice = 0x00000019;
+    private const uint InstallFlagForce = 0x00000001;
+    private const uint InstallFlagNonInteractive = 0x00000004;
+    private const uint SpdrpHardwareId = 0x00000001;
+    private static readonly IntPtr InvalidHandleValue = new IntPtr(-1);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SpDevinfoData {
+      public uint cbSize;
+      public Guid ClassGuid;
+      public uint DevInst;
+      public IntPtr Reserved;
+    }
+
+    [DllImport("setupapi.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool SetupDiGetINFClass(
+      string infName,
+      out Guid classGuid,
+      StringBuilder className,
+      uint classNameSize,
+      out uint requiredSize);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern IntPtr SetupDiCreateDeviceInfoList(
+      ref Guid classGuid,
+      IntPtr hwndParent);
+
+    [DllImport("setupapi.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool SetupDiCreateDeviceInfo(
+      IntPtr deviceInfoSet,
+      string deviceName,
+      ref Guid classGuid,
+      string deviceDescription,
+      IntPtr hwndParent,
+      uint creationFlags,
+      ref SpDevinfoData deviceInfoData);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiSetDeviceRegistryProperty(
+      IntPtr deviceInfoSet,
+      ref SpDevinfoData deviceInfoData,
+      uint property,
+      byte[] propertyBuffer,
+      uint propertyBufferSize);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiCallClassInstaller(
+      uint installFunction,
+      IntPtr deviceInfoSet,
+      ref SpDevinfoData deviceInfoData);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    private static extern bool SetupDiDestroyDeviceInfoList(IntPtr deviceInfoSet);
+
+    [DllImport("newdev.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool UpdateDriverForPlugAndPlayDevices(
+      IntPtr hwndParent,
+      string hardwareId,
+      string fullInfPath,
+      uint installFlags,
+      out bool rebootRequired);
+
+    public static void Install(string infPath, string hardwareId, out bool rebootRequired) {
+      rebootRequired = false;
+
+      Guid classGuid;
+      uint requiredSize;
+      var className = new StringBuilder(256);
+      if (!SetupDiGetINFClass(infPath, out classGuid, className, (uint) className.Capacity, out requiredSize)) {
+        ThrowLastWin32Error("SetupDiGetINFClass");
+      }
+
+      IntPtr deviceInfoSet = SetupDiCreateDeviceInfoList(ref classGuid, IntPtr.Zero);
+      if (deviceInfoSet == InvalidHandleValue) {
+        ThrowLastWin32Error("SetupDiCreateDeviceInfoList");
+      }
+
+      try {
+        var deviceInfoData = new SpDevinfoData();
+        deviceInfoData.cbSize = (uint) Marshal.SizeOf(typeof(SpDevinfoData));
+
+        if (!SetupDiCreateDeviceInfo(
+              deviceInfoSet,
+              className.ToString(),
+              ref classGuid,
+              null,
+              IntPtr.Zero,
+              DicdGenerateId,
+              ref deviceInfoData)) {
+          ThrowLastWin32Error("SetupDiCreateDeviceInfo");
+        }
+
+        byte[] hardwareIds = Encoding.Unicode.GetBytes(hardwareId + "\0\0");
+        if (!SetupDiSetDeviceRegistryProperty(
+              deviceInfoSet,
+              ref deviceInfoData,
+              SpdrpHardwareId,
+              hardwareIds,
+              (uint) hardwareIds.Length)) {
+          ThrowLastWin32Error("SetupDiSetDeviceRegistryProperty");
+        }
+
+        if (!SetupDiCallClassInstaller(DifRegisterDevice, deviceInfoSet, ref deviceInfoData)) {
+          ThrowLastWin32Error("SetupDiCallClassInstaller");
+        }
+      } finally {
+        SetupDiDestroyDeviceInfoList(deviceInfoSet);
+      }
+
+      if (!UpdateDriverForPlugAndPlayDevices(
+            IntPtr.Zero,
+            hardwareId,
+            infPath,
+            InstallFlagForce | InstallFlagNonInteractive,
+            out rebootRequired)) {
+        ThrowLastWin32Error("UpdateDriverForPlugAndPlayDevices");
+      }
+    }
+
+    private static void ThrowLastWin32Error(string action) {
+      int error = Marshal.GetLastWin32Error();
+      throw new InvalidOperationException(
+        action + " failed with Win32 error " + error + ": " + new Win32Exception(error).Message);
+    }
+  }
+}
+"@
+}
+
+function Get-RootDeviceInstanceId {
+  param([string] $TargetHardwareId)
+
+  try {
+    $prefix = "$TargetHardwareId\"
+    @(Get-CimInstance -ClassName Win32_PnPEntity -ErrorAction Stop |
+      Where-Object { $_.PNPDeviceID -like "$prefix*" } |
+      ForEach-Object { $_.PNPDeviceID })
+  } catch {
+    Write-Verbose "Unable to enumerate PnP devices: $($_.Exception.Message)"
+    @()
+  }
+}
+
+function Install-RootDeviceWithSetupApi {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $Path,
+
+    [Parameter(Mandatory = $true)]
+    [string] $TargetHardwareId
+  )
+
+  Add-SetupApiRootDeviceInstaller
+  $rebootRequired = $false
+  [LibVirtualHid.SetupApi.RootDeviceInstaller]::Install($Path, $TargetHardwareId, [ref] $rebootRequired)
+  if ($rebootRequired) {
+    Write-Warning "Windows reported that a reboot is required to finish installing the libvirtualhid driver."
+  }
+}
+
 $resolvedInf = (Resolve-Path -LiteralPath $InfPath).Path
 Import-DriverCertificate -Path $CertificatePath
 
@@ -81,12 +255,19 @@ if ($StageOnly) {
   return
 }
 
-$devcon = Find-Devcon
-if (-not $devcon) {
-  Write-Warning "devcon.exe was not found. The package was staged, but the ROOT\LIBVIRTUALHID development device was not created."
+if ((Get-RootDeviceInstanceId -TargetHardwareId $HardwareId).Count -gt 0) {
+  Write-Information "The $HardwareId device already exists." -InformationAction Continue
   return
 }
 
-if ($PSCmdlet.ShouldProcess($HardwareId, "Create libvirtualhid development device")) {
-  Invoke-CheckedCommand -FilePath $devcon -Arguments @("install", $resolvedInf, $HardwareId)
+$devcon = Find-Devcon
+if ($devcon) {
+  if ($PSCmdlet.ShouldProcess($HardwareId, "Create libvirtualhid development device with devcon")) {
+    Invoke-CheckedCommand -FilePath $devcon -Arguments @("install", $resolvedInf, $HardwareId)
+  }
+  return
+}
+
+if ($PSCmdlet.ShouldProcess($HardwareId, "Create libvirtualhid development device with SetupAPI")) {
+  Install-RootDeviceWithSetupApi -Path $resolvedInf -TargetHardwareId $HardwareId
 }

--- a/scripts/windows/uninstall-driver.ps1
+++ b/scripts/windows/uninstall-driver.ps1
@@ -82,6 +82,20 @@ function Find-PublishedName {
   return $null
 }
 
+function Get-RootDeviceInstanceId {
+  param([string] $TargetHardwareId)
+
+  try {
+    $prefix = "$TargetHardwareId\"
+    @(Get-CimInstance -ClassName Win32_PnPEntity -ErrorAction Stop |
+      Where-Object { $_.PNPDeviceID -like "$prefix*" } |
+      ForEach-Object { $_.PNPDeviceID })
+  } catch {
+    Write-Verbose "Unable to enumerate PnP devices: $($_.Exception.Message)"
+    @()
+  }
+}
+
 function Remove-DriverCertificate {
   [CmdletBinding(SupportsShouldProcess)]
   param([string] $Subject)
@@ -105,6 +119,12 @@ function Remove-DriverCertificate {
 $devcon = Find-Devcon
 if ($devcon -and $PSCmdlet.ShouldProcess($HardwareId, "Remove libvirtualhid development device")) {
   Invoke-CheckedCommand -FilePath $devcon -Arguments @("remove", $HardwareId) -IgnoreFailure
+}
+
+foreach ($instanceId in (Get-RootDeviceInstanceId -TargetHardwareId $HardwareId)) {
+  if ($PSCmdlet.ShouldProcess($instanceId, "Remove libvirtualhid development device with pnputil")) {
+    Invoke-CheckedCommand -FilePath "pnputil.exe" -Arguments @("/remove-device", $instanceId) -IgnoreFailure
+  }
 }
 
 if (-not $PublishedName) {

--- a/src/platform/windows/driver/libvirtualhid_umdf.cpp
+++ b/src/platform/windows/driver/libvirtualhid_umdf.cpp
@@ -45,6 +45,8 @@ using VhfContext = PVOID;  // NOSONAR(cpp:S5008): VHF callback ABI requires PVOI
 
 extern "C" DRIVER_INITIALIZE DriverEntry;
 EVT_WDF_DRIVER_DEVICE_ADD LvhEvtDeviceAdd;
+EVT_WDF_DEVICE_PREPARE_HARDWARE LvhEvtDevicePrepareHardware;
+EVT_WDF_DEVICE_RELEASE_HARDWARE LvhEvtDeviceReleaseHardware;
 EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL LvhEvtIoDeviceControl;
 EVT_WDF_OBJECT_CONTEXT_CLEANUP LvhEvtDeviceCleanup;
 EVT_WDF_REQUEST_CANCEL LvhEvtOutputReadCanceled;
@@ -218,6 +220,11 @@ namespace {
   }
 
   NTSTATUS initialize_vhf_target(WDFDEVICE device) {
+    auto &state = driver_state();
+    if (state.vhf_io_target != nullptr) {
+      return STATUS_SUCCESS;
+    }
+
     WDFIOTARGET vhf_io_target = nullptr;
     WDF_OBJECT_ATTRIBUTES target_attributes;
     WDF_OBJECT_ATTRIBUTES_INIT(&target_attributes);
@@ -236,8 +243,20 @@ namespace {
       return status;
     }
 
-    driver_state().vhf_io_target = vhf_io_target;
+    state.vhf_io_target = vhf_io_target;
     return STATUS_SUCCESS;
+  }
+
+  void reset_vhf_target(bool delete_target) {
+    auto &state = driver_state();
+    const auto vhf_io_target = state.vhf_io_target;
+    state.vhf_io_target = nullptr;
+
+    delete_all_vhf_devices();
+
+    if (delete_target && vhf_io_target != nullptr) {
+      WdfObjectDelete(vhf_io_target);
+    }
   }
 
   NTSTATUS create_vhf_device(const std::shared_ptr<DeviceRecord> &record) {
@@ -463,6 +482,12 @@ extern "C" NTSTATUS DriverEntry(PDRIVER_OBJECT driver_object, PUNICODE_STRING re
 NTSTATUS LvhEvtDeviceAdd(WDFDRIVER driver, PWDFDEVICE_INIT device_init) {
   UNREFERENCED_PARAMETER(driver);
 
+  WDF_PNPPOWER_EVENT_CALLBACKS pnp_callbacks;
+  WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&pnp_callbacks);
+  pnp_callbacks.EvtDevicePrepareHardware = LvhEvtDevicePrepareHardware;
+  pnp_callbacks.EvtDeviceReleaseHardware = LvhEvtDeviceReleaseHardware;
+  WdfDeviceInitSetPnpPowerEventCallbacks(device_init, &pnp_callbacks);
+
   WDFDEVICE device = nullptr;
   WDF_OBJECT_ATTRIBUTES device_attributes;
   WDF_OBJECT_ATTRIBUTES_INIT(&device_attributes);
@@ -482,11 +507,6 @@ NTSTATUS LvhEvtDeviceAdd(WDFDRIVER driver, PWDFDEVICE_INIT device_init) {
   RtlInitUnicodeString(&symbolic_link, symbolic_link_name);
   static_cast<void>(WdfDeviceCreateSymbolicLink(device, &symbolic_link));
 
-  status = initialize_vhf_target(device);
-  if (!NT_SUCCESS(status)) {
-    return status;
-  }
-
   WDF_IO_QUEUE_CONFIG queue_config;
   WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queue_config, WdfIoQueueDispatchParallel);
   queue_config.EvtIoDeviceControl = LvhEvtIoDeviceControl;
@@ -494,12 +514,31 @@ NTSTATUS LvhEvtDeviceAdd(WDFDRIVER driver, PWDFDEVICE_INIT device_init) {
   return WdfIoQueueCreate(device, &queue_config, WDF_NO_OBJECT_ATTRIBUTES, WDF_NO_HANDLE);
 }
 
+NTSTATUS LvhEvtDevicePrepareHardware(
+  WDFDEVICE device,
+  WDFCMRESLIST resources_raw,
+  WDFCMRESLIST resources_translated
+) {
+  UNREFERENCED_PARAMETER(resources_raw);
+  UNREFERENCED_PARAMETER(resources_translated);
+
+  return initialize_vhf_target(device);
+}
+
+NTSTATUS LvhEvtDeviceReleaseHardware(WDFDEVICE device, WDFCMRESLIST resources_translated) {
+  UNREFERENCED_PARAMETER(device);
+  UNREFERENCED_PARAMETER(resources_translated);
+
+  complete_pending_output_requests(STATUS_CANCELLED);
+  reset_vhf_target(true);
+  return STATUS_SUCCESS;
+}
+
 void LvhEvtDeviceCleanup(WDFOBJECT device_object) {
   UNREFERENCED_PARAMETER(device_object);
 
   complete_pending_output_requests(STATUS_CANCELLED);
-  delete_all_vhf_devices();
-  driver_state().vhf_io_target = nullptr;
+  reset_vhf_target(false);
 }
 
 void LvhEvtOutputReadCanceled(WDFREQUEST request) {


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Create the ROOT\LIBVIRTUALHID device without requiring devcon, clean it up on uninstall, and rerun the driver helper during MSI repair/install paths.

Move VHF target initialization from EvtDeviceAdd to EvtDevicePrepareHardware so the UMDF driver starts after PnP has prepared the device stack, avoiding Code 31 startup failures.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
