### PR TITLE
fix(macOS): absolute mouse coordinate scaling

### DIFF
--- a/src/include/libvirtualhid/runtime.hpp
+++ b/src/include/libvirtualhid/runtime.hpp
@@ -417,8 +417,8 @@ namespace lvh {
     /**
      * @brief Submit absolute pointer movement.
      *
-     * @param x Absolute X coordinate.
-     * @param y Absolute Y coordinate.
+     * @param x Absolute X coordinate in the supplied coordinate space.
+     * @param y Absolute Y coordinate in the supplied coordinate space.
      * @param width Width of the absolute coordinate space.
      * @param height Height of the absolute coordinate space.
      * @return Submit operation status.
@@ -428,8 +428,8 @@ namespace lvh {
     /**
      * @brief Submit absolute pointer movement with fractional coordinates.
      *
-     * @param x Absolute X coordinate.
-     * @param y Absolute Y coordinate.
+     * @param x Absolute X coordinate in the supplied coordinate space, preserving fractional precision.
+     * @param y Absolute Y coordinate in the supplied coordinate space, preserving fractional precision.
      * @param width Width of the absolute coordinate space.
      * @param height Height of the absolute coordinate space.
      * @return Submit operation status.

--- a/src/include/libvirtualhid/types.hpp
+++ b/src/include/libvirtualhid/types.hpp
@@ -813,22 +813,22 @@ namespace lvh {
     MouseEventKind kind = MouseEventKind::relative_motion;
 
     /**
-     * @brief Relative delta or absolute X coordinate.
+     * @brief Relative delta or absolute X coordinate in the supplied coordinate space.
      */
     std::int32_t x = 0;
 
     /**
-     * @brief Relative delta or absolute Y coordinate.
+     * @brief Relative delta or absolute Y coordinate in the supplied coordinate space.
      */
     std::int32_t y = 0;
 
     /**
-     * @brief Fractional absolute X coordinate used when `has_fractional_absolute_coordinates` is true.
+     * @brief Absolute X coordinate with fractional precision, used when `has_fractional_absolute_coordinates` is true.
      */
     float absolute_x = 0.0F;
 
     /**
-     * @brief Fractional absolute Y coordinate used when `has_fractional_absolute_coordinates` is true.
+     * @brief Absolute Y coordinate with fractional precision, used when `has_fractional_absolute_coordinates` is true.
      */
     float absolute_y = 0.0F;
 

--- a/src/platform/macos/macos_backend.cpp
+++ b/src/platform/macos/macos_backend.cpp
@@ -345,6 +345,39 @@ namespace lvh::detail {
     }
 
     /**
+     * @brief Scale one absolute mouse axis into a display-sized coordinate.
+     *
+     * @param value Absolute coordinate in the source coordinate space.
+     * @param limit Size of the source coordinate space.
+     * @param display_size Size of the target display coordinate space.
+     * @return Coordinate offset within the target display bounds.
+     */
+    inline CGFloat scale_absolute_axis(float value, std::int32_t limit, CGFloat display_size) {
+      if (limit <= 0 || display_size <= 0) {
+        return 0;
+      }
+
+      const auto clamped = std::clamp(value, 0.0F, static_cast<float>(limit));
+      return static_cast<CGFloat>(clamped) * display_size / static_cast<CGFloat>(limit);
+    }
+
+    /**
+     * @brief Convert a libvirtualhid absolute mouse event to a CoreGraphics location.
+     *
+     * @param event Mouse event to translate.
+     * @param display_bounds Target display bounds.
+     * @return CoreGraphics display location.
+     */
+    inline CGPoint absolute_mouse_location(const MouseEvent &event, const CGRect &display_bounds) {
+      const auto x = event.has_fractional_absolute_coordinates ? event.absolute_x : static_cast<float>(event.x);
+      const auto y = event.has_fractional_absolute_coordinates ? event.absolute_y : static_cast<float>(event.y);
+      return CGPoint {
+        display_bounds.origin.x + scale_absolute_axis(x, event.width, display_bounds.size.width),
+        display_bounds.origin.y + scale_absolute_axis(y, event.height, display_bounds.size.height)
+      };
+    }
+
+    /**
      * @brief Shared macOS backend state.
      */
     class MacosInputState {
@@ -632,12 +665,7 @@ namespace lvh::detail {
 
       OperationStatus submit_absolute_motion(const MouseEvent &event) {
         const auto display_bounds = CGDisplayBounds(state_->display);
-        const auto location = CGPoint {
-          event.has_fractional_absolute_coordinates ? display_bounds.origin.x + event.absolute_x * display_bounds.size.width :
-                                                      static_cast<CGFloat>(event.x) * state_->display_scaling + display_bounds.origin.x,
-          event.has_fractional_absolute_coordinates ? display_bounds.origin.y + event.absolute_y * display_bounds.size.height :
-                                                      static_cast<CGFloat>(event.y) * state_->display_scaling + display_bounds.origin.y
-        };
+        const auto location = absolute_mouse_location(event, display_bounds);
         return post_mouse(kCGMouseButtonLeft, event_type_for_current_buttons(), location, current_location(), 0);
       }
 

--- a/tests/fixtures/include/fixtures/macos_backend_test_hooks.hpp
+++ b/tests/fixtures/include/fixtures/macos_backend_test_hooks.hpp
@@ -14,6 +14,14 @@
 namespace lvh::detail::test {
 
   /**
+   * @brief Portable representation of a CoreGraphics point for tests.
+   */
+  struct MacosPoint {
+    double x {};  ///< Horizontal coordinate.
+    double y {};  ///< Vertical coordinate.
+  };
+
+  /**
    * @brief Result set for macOS backend lifecycle utility coverage.
    */
   struct MacosBackendUtilityResult {
@@ -66,6 +74,24 @@ namespace lvh::detail::test {
    * @return Pixel distance to send to CoreGraphics.
    */
   int macos_backend_scroll_pixels(std::int32_t high_resolution_distance, int pixels_per_line, int lines_per_detent);
+
+  /**
+   * @brief Convert an absolute mouse event to a macOS display location.
+   *
+   * @param event Mouse event to convert.
+   * @param origin_x Display origin X coordinate.
+   * @param origin_y Display origin Y coordinate.
+   * @param width Display width.
+   * @param height Display height.
+   * @return Display location that the macOS backend will post.
+   */
+  MacosPoint macos_backend_absolute_mouse_location(
+    const MouseEvent &event,
+    double origin_x,
+    double origin_y,
+    double width,
+    double height
+  );
 
   /**
    * @brief Exercise macOS backend creation and unsupported-device paths.

--- a/tests/fixtures/macos_backend_test_hooks.cpp
+++ b/tests/fixtures/macos_backend_test_hooks.cpp
@@ -39,6 +39,23 @@ namespace lvh::detail::test {
     return macos::scroll_pixels(high_resolution_distance, pixels_per_line, lines_per_detent);
   }
 
+  MacosPoint macos_backend_absolute_mouse_location(
+    const MouseEvent &event,
+    double origin_x,
+    double origin_y,
+    double width,
+    double height
+  ) {
+    const auto location = macos::absolute_mouse_location(
+      event,
+      CGRect {
+        .origin = CGPoint {origin_x, origin_y},
+        .size = CGSize {width, height}
+      }
+    );
+    return {.x = location.x, .y = location.y};
+  }
+
   MacosBackendUtilityResult macos_backend_utilities() {
     auto backend = create_platform_backend_for_macos_backend_test_hooks();
     MacosBackendUtilityResult result;

--- a/tests/unit/test_macos_backend.cpp
+++ b/tests/unit/test_macos_backend.cpp
@@ -76,6 +76,38 @@ TEST_F(MacosBackendTest, ConvertsScrollSettings) {
   EXPECT_EQ(lvh::detail::test::macos_backend_scroll_pixels(120, 0, 0), 1);
 }
 
+TEST_F(MacosBackendTest, ConvertsAbsoluteMouseCoordinates) {
+  lvh::MouseEvent event {
+    .kind = lvh::MouseEventKind::absolute_motion,
+    .x = 40,
+    .y = 50,
+    .width = 200,
+    .height = 100,
+  };
+
+  auto location = lvh::detail::test::macos_backend_absolute_mouse_location(event, 10.0, 20.0, 400.0, 200.0);
+  EXPECT_DOUBLE_EQ(location.x, 90.0);
+  EXPECT_DOUBLE_EQ(location.y, 120.0);
+
+  event.x = 250;
+  event.y = -10;
+  location = lvh::detail::test::macos_backend_absolute_mouse_location(event, 10.0, 20.0, 400.0, 200.0);
+  EXPECT_DOUBLE_EQ(location.x, 410.0);
+  EXPECT_DOUBLE_EQ(location.y, 20.0);
+
+  event = {
+    .kind = lvh::MouseEventKind::absolute_motion,
+    .absolute_x = 0.25F,
+    .absolute_y = 0.75F,
+    .has_fractional_absolute_coordinates = true,
+    .width = 1,
+    .height = 1,
+  };
+  location = lvh::detail::test::macos_backend_absolute_mouse_location(event, 10.0, 20.0, 400.0, 200.0);
+  EXPECT_DOUBLE_EQ(location.x, 110.0);
+  EXPECT_DOUBLE_EQ(location.y, 170.0);
+}
+
 TEST_F(MacosBackendTest, ReportsCapabilitiesAndUnsupportedDevices) {
   const auto result = lvh::detail::test::macos_backend_utilities();
 

--- a/tests/unit/test_runtime.cpp
+++ b/tests/unit/test_runtime.cpp
@@ -239,10 +239,21 @@ TEST(RuntimeTest, CreatesSubmitsAndClosesMouse) {
   EXPECT_EQ(created.mouse->last_submitted_event().y, -5);
 
   EXPECT_TRUE(created.mouse->move_absolute(100, 200, 1920, 1080).ok());
+  EXPECT_EQ(created.mouse->last_submitted_event().kind, lvh::MouseEventKind::absolute_motion);
+  EXPECT_EQ(created.mouse->last_submitted_event().x, 100);
+  EXPECT_EQ(created.mouse->last_submitted_event().y, 200);
+  EXPECT_EQ(created.mouse->last_submitted_event().width, 1920);
+  EXPECT_EQ(created.mouse->last_submitted_event().height, 1080);
+
+  EXPECT_TRUE(created.mouse->move_absolute(0.25F, 0.75F, 1, 1).ok());
+  EXPECT_EQ(created.mouse->last_submitted_event().kind, lvh::MouseEventKind::absolute_motion);
+  EXPECT_TRUE(created.mouse->last_submitted_event().has_fractional_absolute_coordinates);
+  EXPECT_FLOAT_EQ(created.mouse->last_submitted_event().absolute_x, 0.25F);
+  EXPECT_FLOAT_EQ(created.mouse->last_submitted_event().absolute_y, 0.75F);
   EXPECT_TRUE(created.mouse->button(lvh::MouseButton::right, true).ok());
   EXPECT_TRUE(created.mouse->vertical_scroll(120).ok());
   EXPECT_TRUE(created.mouse->horizontal_scroll(-120).ok());
-  EXPECT_EQ(created.mouse->submit_count(), 5U);
+  EXPECT_EQ(created.mouse->submit_count(), 6U);
 
   EXPECT_EQ(created.mouse->move_absolute(1, 1, 0, 0).code(), lvh::ErrorCode::invalid_argument);
   EXPECT_TRUE(created.mouse->close().ok());


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Normalize absolute mouse motion on macOS to the event-provided coordinate space instead of using display scaling assumptions, with clamping to valid source bounds before mapping to display coordinates. This also clarifies public API docs for absolute and fractional coordinates, adds test hooks and unit coverage for coordinate conversion behavior, and expands runtime mouse tests to assert absolute event fields for both integer and fractional submissions.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [ ] Code follows the style guidelines of this project
- [ ] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
