### PR TITLE
fix(macOS): correct right and middle mouse drag handling

### DIFF
--- a/src/platform/macos/macos_backend.cpp
+++ b/src/platform/macos/macos_backend.cpp
@@ -618,12 +618,25 @@ namespace lvh::detail {
           return kCGEventLeftMouseDragged;
         }
         if (mouse_down_[1]) {
-          return kCGEventOtherMouseDragged;
-        }
-        if (mouse_down_[2]) {
           return kCGEventRightMouseDragged;
         }
+        if (mouse_down_[2]) {
+          return kCGEventOtherMouseDragged;
+        }
         return kCGEventMouseMoved;
+      }
+
+      CGMouseButton button_for_current_buttons() const {
+        if (mouse_down_[0]) {
+          return kCGMouseButtonLeft;
+        }
+        if (mouse_down_[1]) {
+          return kCGMouseButtonRight;
+        }
+        if (mouse_down_[2]) {
+          return kCGMouseButtonCenter;
+        }
+        return kCGMouseButtonLeft;
       }
 
       OperationStatus post_mouse(
@@ -660,13 +673,13 @@ namespace lvh::detail {
       OperationStatus submit_relative_motion(std::int32_t delta_x, std::int32_t delta_y) {
         const auto current = current_location();
         const auto location = CGPoint {current.x + delta_x, current.y + delta_y};
-        return post_mouse(kCGMouseButtonLeft, event_type_for_current_buttons(), location, current, 0);
+        return post_mouse(button_for_current_buttons(), event_type_for_current_buttons(), location, current, 0);
       }
 
       OperationStatus submit_absolute_motion(const MouseEvent &event) {
         const auto display_bounds = CGDisplayBounds(state_->display);
         const auto location = absolute_mouse_location(event, display_bounds);
-        return post_mouse(kCGMouseButtonLeft, event_type_for_current_buttons(), location, current_location(), 0);
+        return post_mouse(button_for_current_buttons(), event_type_for_current_buttons(), location, current_location(), 0);
       }
 
       OperationStatus submit_button(const MouseEvent &event) {

--- a/src/platform/macos/macos_backend.cpp
+++ b/src/platform/macos/macos_backend.cpp
@@ -532,6 +532,14 @@ namespace lvh::detail {
     };
 
     /**
+     * @brief CoreGraphics metadata for a mouse motion event.
+     */
+    struct MacosMouseMotion {
+      CGMouseButton button {};  ///< CoreGraphics button associated with the motion.
+      CGEventType event_type {};  ///< CoreGraphics motion event type.
+    };
+
+    /**
      * @brief Translate a portable mouse button to CoreGraphics metadata.
      *
      * @param button Portable mouse button.
@@ -553,6 +561,25 @@ namespace lvh::detail {
       }
 
       return std::nullopt;
+    }
+
+    /**
+     * @brief Select CoreGraphics motion metadata for the currently held mouse buttons.
+     *
+     * @param mouse_down Local left, right, and middle button state.
+     * @return Matching CoreGraphics button and motion event type.
+     */
+    inline MacosMouseMotion macos_mouse_motion(const std::array<bool, 3> &mouse_down) {
+      if (mouse_down[0]) {
+        return {kCGMouseButtonLeft, kCGEventLeftMouseDragged};
+      }
+      if (mouse_down[1]) {
+        return {kCGMouseButtonRight, kCGEventRightMouseDragged};
+      }
+      if (mouse_down[2]) {
+        return {kCGMouseButtonCenter, kCGEventOtherMouseDragged};
+      }
+      return {kCGMouseButtonLeft, kCGEventMouseMoved};
     }
 
     /**
@@ -613,32 +640,6 @@ namespace lvh::detail {
         return current;
       }
 
-      CGEventType event_type_for_current_buttons() const {
-        if (mouse_down_[0]) {
-          return kCGEventLeftMouseDragged;
-        }
-        if (mouse_down_[1]) {
-          return kCGEventRightMouseDragged;
-        }
-        if (mouse_down_[2]) {
-          return kCGEventOtherMouseDragged;
-        }
-        return kCGEventMouseMoved;
-      }
-
-      CGMouseButton button_for_current_buttons() const {
-        if (mouse_down_[0]) {
-          return kCGMouseButtonLeft;
-        }
-        if (mouse_down_[1]) {
-          return kCGMouseButtonRight;
-        }
-        if (mouse_down_[2]) {
-          return kCGMouseButtonCenter;
-        }
-        return kCGMouseButtonLeft;
-      }
-
       OperationStatus post_mouse(
         CGMouseButton button,
         CGEventType type,
@@ -673,13 +674,15 @@ namespace lvh::detail {
       OperationStatus submit_relative_motion(std::int32_t delta_x, std::int32_t delta_y) {
         const auto current = current_location();
         const auto location = CGPoint {current.x + delta_x, current.y + delta_y};
-        return post_mouse(button_for_current_buttons(), event_type_for_current_buttons(), location, current, 0);
+        const auto motion = macos_mouse_motion(mouse_down_);
+        return post_mouse(motion.button, motion.event_type, location, current, 0);
       }
 
       OperationStatus submit_absolute_motion(const MouseEvent &event) {
         const auto display_bounds = CGDisplayBounds(state_->display);
         const auto location = absolute_mouse_location(event, display_bounds);
-        return post_mouse(button_for_current_buttons(), event_type_for_current_buttons(), location, current_location(), 0);
+        const auto motion = macos_mouse_motion(mouse_down_);
+        return post_mouse(motion.button, motion.event_type, location, current_location(), 0);
       }
 
       OperationStatus submit_button(const MouseEvent &event) {

--- a/tests/fixtures/include/fixtures/macos_backend_test_hooks.hpp
+++ b/tests/fixtures/include/fixtures/macos_backend_test_hooks.hpp
@@ -22,6 +22,14 @@ namespace lvh::detail::test {
   };
 
   /**
+   * @brief Portable representation of CoreGraphics mouse motion metadata for tests.
+   */
+  struct MacosMouseMotionResult {
+    std::uint32_t button {};  ///< CoreGraphics mouse button value.
+    std::uint32_t event_type {};  ///< CoreGraphics mouse event type value.
+  };
+
+  /**
    * @brief Result set for macOS backend lifecycle utility coverage.
    */
   struct MacosBackendUtilityResult {
@@ -92,6 +100,16 @@ namespace lvh::detail::test {
     double width,
     double height
   );
+
+  /**
+   * @brief Select CoreGraphics motion metadata for a mouse button state.
+   *
+   * @param left_down Whether the left button is held.
+   * @param right_down Whether the right button is held.
+   * @param middle_down Whether the middle button is held.
+   * @return CoreGraphics button and motion event type values.
+   */
+  MacosMouseMotionResult macos_backend_mouse_motion(bool left_down, bool right_down, bool middle_down);
 
   /**
    * @brief Exercise macOS backend creation and unsupported-device paths.

--- a/tests/fixtures/macos_backend_test_hooks.cpp
+++ b/tests/fixtures/macos_backend_test_hooks.cpp
@@ -56,6 +56,14 @@ namespace lvh::detail::test {
     return {.x = location.x, .y = location.y};
   }
 
+  MacosMouseMotionResult macos_backend_mouse_motion(bool left_down, bool right_down, bool middle_down) {
+    const auto motion = macos::macos_mouse_motion({left_down, right_down, middle_down});
+    return {
+      .button = static_cast<std::uint32_t>(motion.button),
+      .event_type = static_cast<std::uint32_t>(motion.event_type),
+    };
+  }
+
   MacosBackendUtilityResult macos_backend_utilities() {
     auto backend = create_platform_backend_for_macos_backend_test_hooks();
     MacosBackendUtilityResult result;

--- a/tests/unit/test_macos_backend.cpp
+++ b/tests/unit/test_macos_backend.cpp
@@ -104,6 +104,26 @@ TEST_F(MacosBackendTest, ConvertsAbsoluteMouseCoordinates) {
   EXPECT_DOUBLE_EQ(location.y, 170.0);
 }
 
+TEST_F(MacosBackendTest, SelectsMouseMotionMetadataForHeldButtons) {
+  using lvh::detail::test::macos_backend_mouse_motion;
+
+  auto motion = macos_backend_mouse_motion(false, false, false);
+  EXPECT_EQ(motion.button, kCGMouseButtonLeft);
+  EXPECT_EQ(motion.event_type, kCGEventMouseMoved);
+
+  motion = macos_backend_mouse_motion(true, false, false);
+  EXPECT_EQ(motion.button, kCGMouseButtonLeft);
+  EXPECT_EQ(motion.event_type, kCGEventLeftMouseDragged);
+
+  motion = macos_backend_mouse_motion(false, true, false);
+  EXPECT_EQ(motion.button, kCGMouseButtonRight);
+  EXPECT_EQ(motion.event_type, kCGEventRightMouseDragged);
+
+  motion = macos_backend_mouse_motion(false, false, true);
+  EXPECT_EQ(motion.button, kCGMouseButtonCenter);
+  EXPECT_EQ(motion.event_type, kCGEventOtherMouseDragged);
+}
+
 TEST_F(MacosBackendTest, ReportsCapabilitiesAndUnsupportedDevices) {
   const auto result = lvh::detail::test::macos_backend_utilities();
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->

Fixes macOS right and middle mouse drag handling in the CoreGraphics mouse backend.

I encountered an issue while using Sunshine as a macOS host with Moonlight as the client where a normal right-click worked, but holding the right mouse button while moving the mouse did not behave correctly.

The macOS backend tracks mouse button state with index 0 as left, 1 as right, and 2 as middle. However, `event_type_for_current_buttons()` mapped the right button to `kCGEventOtherMouseDragged` and the middle button to `kCGEventRightMouseDragged`.

This change corrects those mappings so that:
- the right mouse button generates `kCGEventRightMouseDragged`
- the middle mouse button generates `kCGEventOtherMouseDragged`

It also adds selection of the currently held mouse button for relative and absolute mouse movement. Previously these movement events always passed `kCGMouseButtonLeft` to `post_mouse()`, even when the right or middle button was being held.

I tested the change using Sunshine on macOS with Moonlight as the client. Before the change, right-click worked but right-click-and-hold with mouse movement did not work correctly.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [x] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes